### PR TITLE
Ajouter contrat 270 (capot beloté)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Le serveur demarre sur `http://localhost:3000`.
 
 - 4 joueurs: Nord-Sud vs Est-Ouest.
 - 32 cartes: `7 8 9 10 valet dame roi as`.
-- Contrats: `80` a `160`, `250` (capot), `400`, `500` (generale).
+- Contrats: `80` a `160`, `250` (capot), `270` (capot belote), `500` (generale).
 - Atouts: `coeur`, `carreau`, `trefle`, `pique`, `tout-atout`, `sans-atout`.
 - Dernier pli: +10 points.
 - Belote/Rebelote: +20 points (selon les conditions du contrat).

--- a/game.js
+++ b/game.js
@@ -522,7 +522,7 @@ class CoincheGame {
     if (bid.type === 'bid') {
       if (this.coincheBy) return { success: false, error: 'Enchère coinchée, vous pouvez seulement passer ou surcoincher' };
 
-      const validPoints = [80, 90, 100, 110, 120, 130, 140, 150, 160, 250, 400, 500];
+      const validPoints = [80, 90, 100, 110, 120, 130, 140, 150, 160, 250, 270, 500];
       if (!validPoints.includes(bid.points)) {
         return { success: false, error: 'Nombre de points invalide' };
       }
@@ -672,9 +672,16 @@ class CoincheGame {
 
     let contractMet = contractPoints >= this.contract.points;
 
-    // Capot: si contrat de 250 (capot), il faut tous les plis
+    // Capot: il faut tous les plis de l'équipe
     if (this.contract.points === 250) {
       contractMet = this.tricksTaken[defenseTeam].length === 0;
+    }
+
+    // Capot beloté (270): tous les plis + belote/rebelote de l'attaque
+    if (this.contract.points === 270) {
+      const tookAllTricks = this.tricksTaken[defenseTeam].length === 0;
+      const hasBelote = Object.values(this.beloteAnnounced[contractTeam]).some(v => v === 'rebelote');
+      contractMet = tookAllTricks && hasBelote;
     }
 
     // Générale: 500 points
@@ -697,6 +704,9 @@ class CoincheGame {
       if (contractTeam === 'ns') {
         if (this.contract.points === 250 || this.contract.points === 500) {
           scoreNS = contractBonus + belotePoints.ns;
+        } else if (this.contract.points === 270) {
+          // Capot beloté: 270 inclut déjà la belote
+          scoreNS = contractBonus;
         } else {
           scoreNS = contractPoints + contractBonus;
         }
@@ -704,6 +714,9 @@ class CoincheGame {
       } else {
         if (this.contract.points === 250 || this.contract.points === 500) {
           scoreEO = contractBonus + belotePoints.eo;
+        } else if (this.contract.points === 270) {
+          // Capot beloté: 270 inclut déjà la belote
+          scoreEO = contractBonus;
         } else {
           scoreEO = contractPoints + contractBonus;
         }

--- a/public/game-client.js
+++ b/public/game-client.js
@@ -68,6 +68,13 @@ function getCardColor(suit) {
   return (suit === 'coeur' || suit === 'carreau') ? 'red' : 'black';
 }
 
+function formatBidPoints(points) {
+  if (points === 270) return 'Capot beloté (270)';
+  if (points === 250) return 'Capot (250)';
+  if (points === 500) return 'Générale (500)';
+  return `${points}`;
+}
+
 function getFaceFigureMarkup(card) {
   const figureMap = {
     valet: {
@@ -405,7 +412,7 @@ function updateRoundHistory() {
         <span class="history-entry-status ${statusClass}">${entry.contractMet ? 'réussi' : 'chuté'}</span>
       </div>
       <div class="history-entry-details">
-        Contrat: <strong>${entry.contract.points} ${suitNames[entry.contract.suit] || entry.contract.suit}</strong><br>
+        Contrat: <strong>${formatBidPoints(entry.contract.points)} ${suitNames[entry.contract.suit] || entry.contract.suit}</strong><br>
         Manche: NS <strong>${entry.scoreNS}</strong> - EO <strong>${entry.scoreEO}</strong><br>
         Total: NS <strong>${entry.totalScores.ns}</strong> - EO <strong>${entry.totalScores.eo}</strong>
       </div>
@@ -470,7 +477,7 @@ function updateBidding() {
         div.innerHTML = `<strong>${name}</strong> SURCOINCHE !`;
       } else if (bid.type === 'bid') {
         div.className = 'bid-entry';
-        div.innerHTML = `<strong>${name}</strong> ${bid.points} ${suitNames[bid.suit] || bid.suit}`;
+        div.innerHTML = `<strong>${name}</strong> ${formatBidPoints(bid.points)} ${suitNames[bid.suit] || bid.suit}`;
       }
       history.appendChild(div);
     }
@@ -504,10 +511,9 @@ function updateBidding() {
 
   // Update minimum bid
   if (gameState.contract) {
-    const minBid = gameState.contract.points + 10;
     for (const opt of pointsSelect.options) {
       const val = parseInt(opt.value);
-      opt.disabled = val <= gameState.contract.points && val < 250;
+      opt.disabled = val <= gameState.contract.points;
     }
     if (pointsSelect.selectedOptions[0] && pointsSelect.selectedOptions[0].disabled) {
       const firstValid = Array.from(pointsSelect.options).find(o => !o.disabled);
@@ -534,7 +540,7 @@ function updateContract() {
       coeur: '♥ Coeur', carreau: '♦ Carreau', trefle: '♣ Trèfle',
       pique: '♠ Pique', 'tout-atout': 'Tout Atout', 'sans-atout': 'Sans Atout'
     };
-    let text = `Contrat: ${gameState.contract.points} ${suitNames[gameState.contract.suit]}`;
+    let text = `Contrat: ${formatBidPoints(gameState.contract.points)} ${suitNames[gameState.contract.suit]}`;
     if (gameState.contract.coinched) text += ' (COINCHÉ)';
     if (gameState.contract.surcoinched) text += ' (SURCOINCÉ)';
     el.querySelector('#contract-text').textContent = text;

--- a/public/index.html
+++ b/public/index.html
@@ -195,7 +195,7 @@
             <option value="150">150</option>
             <option value="160">160</option>
             <option value="250">Capot (250)</option>
-            <option value="400">400</option>
+            <option value="270">Capot beloté (270)</option>
             <option value="500">Générale (500)</option>
           </select>
           <select id="bid-suit">

--- a/server.js
+++ b/server.js
@@ -34,6 +34,13 @@ function broadcastMessage(roomId, message, type = 'info') {
   io.to(roomId).emit('message', { text: message, type });
 }
 
+function formatBidPoints(points) {
+  if (points === 270) return 'Capot beloté (270)';
+  if (points === 250) return 'Capot (250)';
+  if (points === 500) return 'Générale (500)';
+  return `${points}`;
+}
+
 io.on('connection', (socket) => {
   console.log(`Joueur connecté: ${socket.id}`);
 
@@ -128,7 +135,7 @@ io.on('connection', (socket) => {
     } else if (data.type === 'surcoinche') {
       broadcastMessage(currentRoom, `${playerName} SURCOINCHE !`, 'danger');
     } else if (data.type === 'bid') {
-      broadcastMessage(currentRoom, `${playerName} annonce ${data.points} ${suitNames[data.suit] || data.suit}`);
+      broadcastMessage(currentRoom, `${playerName} annonce ${formatBidPoints(data.points)} ${suitNames[data.suit] || data.suit}`);
     }
 
     if (result.action === 'redistribute') {
@@ -138,7 +145,7 @@ io.on('connection', (socket) => {
 
     if (result.action === 'play') {
       const suitName = suitNames[game.contract.suit] || game.contract.suit;
-      let msg = `Contrat: ${game.contract.points} ${suitName} par ${game.players[game.contract.player].name}`;
+      let msg = `Contrat: ${formatBidPoints(game.contract.points)} ${suitName} par ${game.players[game.contract.player].name}`;
       if (game.contract.coinched) msg += ' (COINCHÉ)';
       if (game.contract.surcoinched) msg += ' (SURCOINCÉ)';
       broadcastMessage(currentRoom, msg, 'success');


### PR DESCRIPTION
Introduce le nouveau type de contrat 270 «capot beloté». Mises à jour :

- game.js: autorise 270 dans les valeurs d'enchères; logique de réussite de contrat étendue pour 270 (nécessite tous les plis + belote/rebelote annoncée) et ajustement du calcul de score pour inclure le cas spécial où la belote est déjà comptée.
- public/game-client.js: ajout d'un helper formatBidPoints pour afficher lisiblement 270 («Capot beloté (270)»), utilisation dans l'historique, l'affichage du contrat et la liste d'enchères; ajustement de la logique de désactivation des options de points.
- public/index.html: remplacement de l'option 400 par l'option 270 dans la liste d'enchères affichée.
- server.js: ajout de formatBidPoints côté serveur et utilisation pour les messages broadcast concernant les annonces et le contrat.
- README.md: documentation mise à jour pour mentionner le nouveau contrat 270.

But: cohérence UI/serveur/jeu pour gérer et afficher proprement le nouveau contrat.