### PR TITLE
Add public rooms support (UI + server)

### DIFF
--- a/public/game-client.js
+++ b/public/game-client.js
@@ -49,8 +49,14 @@ const chatUi = {
   closeBtn: document.getElementById('btn-chat-close')
 };
 
+const publicRoomsUi = {
+  list: document.getElementById('public-rooms-list'),
+  refreshBtn: document.getElementById('btn-public-refresh')
+};
+
 const CHAT_MAX_MESSAGES = 120;
 const PANEL_POS_STORAGE_PREFIX = 'coinche-panel-pos:';
+const PUBLIC_ROOMS_REFRESH_MS = 10000;
 
 function isMobilePortraitGameplay() {
   // Matches the CSS breakpoint used for portrait-phone gameplay overrides.
@@ -901,6 +907,36 @@ document.getElementById('btn-join').addEventListener('click', () => {
   socket.emit('join-room', { name, roomId, position });
 });
 
+const publicCreateBtn = document.getElementById('btn-public-create');
+if (publicCreateBtn) {
+  publicCreateBtn.addEventListener('click', () => {
+    const name = document.getElementById('player-name').value.trim() || 'Joueur';
+    socket.emit('create-public-room', { name });
+  });
+}
+
+const publicJoinBtn = document.getElementById('btn-public-join');
+if (publicJoinBtn) {
+  publicJoinBtn.addEventListener('click', () => {
+    requestPublicRooms();
+  });
+}
+
+if (publicRoomsUi.refreshBtn) {
+  publicRoomsUi.refreshBtn.addEventListener('click', () => {
+    requestPublicRooms();
+  });
+}
+
+const quickPlayBtn = document.getElementById('btn-quick-play');
+if (quickPlayBtn) {
+  // Compatibilite si l'ancien bouton est encore present
+  quickPlayBtn.addEventListener('click', () => {
+    const name = document.getElementById('player-name').value.trim() || 'Joueur';
+    socket.emit('join-public-room', { name });
+  });
+}
+
 // Update available positions when typing room code
 document.getElementById('room-code').addEventListener('input', (e) => {
   const code = e.target.value.trim();
@@ -908,6 +944,65 @@ document.getElementById('room-code').addEventListener('input', (e) => {
     socket.emit('get-available-positions', { roomId: code });
   }
 });
+
+function requestPublicRooms() {
+  socket.emit('list-public-rooms');
+}
+
+function renderPublicRooms(rooms) {
+  if (!publicRoomsUi.list) return;
+
+  publicRoomsUi.list.innerHTML = '';
+
+  if (!Array.isArray(rooms) || rooms.length === 0) {
+    publicRoomsUi.list.innerHTML = '<div class="public-rooms-empty">Aucune salle publique disponible pour le moment.</div>';
+    return;
+  }
+
+  for (const room of rooms) {
+    const row = document.createElement('div');
+    row.className = 'public-room-entry';
+
+    const meta = document.createElement('div');
+    meta.className = 'public-room-meta';
+    meta.innerHTML = `
+      <div class="public-room-title">${room.roomName || room.displayCode || room.roomId}</div>
+      <div class="public-room-subtitle">${room.playerCount}/4 joueurs · ${room.freeSeats} place(s) libre(s)</div>
+    `;
+
+    const joinBtn = document.createElement('button');
+    joinBtn.className = 'btn btn-secondary btn-sm';
+    joinBtn.type = 'button';
+    joinBtn.textContent = 'Rejoindre';
+    joinBtn.addEventListener('click', () => {
+      const name = document.getElementById('player-name').value.trim() || 'Joueur';
+      socket.emit('join-public-room', { name, roomId: room.roomId });
+    });
+
+    row.appendChild(meta);
+    row.appendChild(joinBtn);
+    publicRoomsUi.list.appendChild(row);
+  }
+}
+
+socket.on('public-rooms', (data) => {
+  renderPublicRooms(data?.rooms || []);
+});
+
+socket.on('public-room-closed', () => {
+  myRoom = null;
+  myPosition = null;
+  gameState = null;
+  showScreen('lobby');
+  requestPublicRooms();
+});
+
+setInterval(() => {
+  if (!screens?.lobby || screens.lobby.classList.contains('hidden')) return;
+  requestPublicRooms();
+}, PUBLIC_ROOMS_REFRESH_MS);
+
+requestPublicRooms();
 
 socket.on('available-positions', (data) => {
   const select = document.getElementById('join-position');
@@ -931,11 +1026,29 @@ function showError(msg) {
   setTimeout(() => el.classList.add('hidden'), 3000);
 }
 
+function updateWaitingRoomRoomInfo(data) {
+  const display = document.getElementById('room-code-display');
+  const help = document.getElementById('waiting-room-help');
+  const isPublic = !!data?.isPublic;
+
+  if (display) {
+    display.textContent = isPublic
+      ? (data.roomName || data.displayCode || data.roomId || '')
+      : (data.displayCode || data.roomId || '');
+  }
+
+  if (help) {
+    help.textContent = isPublic
+      ? 'Partagez ce nom de salle avec vos amis !'
+      : 'Partagez ce code de salle avec vos amis !';
+  }
+}
+
 // ---- Socket events ----
 socket.on('room-created', (data) => {
   myRoom = data.roomId;
   myPosition = data.position;
-  document.getElementById('room-code-display').textContent = data.roomId;
+  updateWaitingRoomRoomInfo(data);
   clearChat();
   showScreen('waiting');
 });
@@ -943,7 +1056,7 @@ socket.on('room-created', (data) => {
 socket.on('room-joined', (data) => {
   myRoom = data.roomId;
   myPosition = data.position;
-  document.getElementById('room-code-display').textContent = data.roomId;
+  updateWaitingRoomRoomInfo(data);
   clearChat();
   showScreen('waiting');
 });

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,8 @@
     <div class="lobby-container">
       <img class="brand-logo brand-logo-lobby" src="/logo/logo.png" alt="Logo Cari'Coinche" loading="eager"
         decoding="async">
-      <h1 class="subtitle">♠ Jeu de cartes multijoueur♥</h1>
+      <h1 class="lobby-title">♠ Jeu de cartes multijoueur♥</h1>
+      <p class="subtitle">Coinche en ligne, 4 joueurs, parties privées et publiques</p>
 
       <div class="lobby-form">
         <input type="text" id="player-name" placeholder="Ton pseudo" maxlength="20" autocomplete="off">
@@ -53,6 +54,22 @@
             <button id="btn-join" class="btn btn-secondary">Rejoindre</button>
           </div>
         </div>
+
+        <div class="public-menu">
+          <h3>Parties publiques</h3>
+          <p class="public-menu-help">Crée une salle publique ou rejoins-en une si une place est disponible.</p>
+          <div class="public-menu-actions">
+            <button id="btn-public-create" class="btn btn-primary">Créer une salle publique</button>
+            <button id="btn-public-join" class="btn btn-secondary">Voir les salles publiques</button>
+          </div>
+          <div class="public-rooms-panel">
+            <div class="public-rooms-header">
+              <span>Salles disponibles</span>
+              <button id="btn-public-refresh" class="btn btn-secondary btn-sm" type="button">Rafraîchir</button>
+            </div>
+            <div id="public-rooms-list" class="public-rooms-list"></div>
+          </div>
+        </div>
       </div>
 
       <div id="lobby-error" class="error-msg hidden"></div>
@@ -65,7 +82,7 @@
       <img class="brand-logo brand-logo-waiting" src="/logo/logo.png" alt="Logo Cari'Coinche" loading="lazy"
         decoding="async">
       <h2>Salle: <span id="room-code-display"></span></h2>
-      <p>Partagez ce code avec vos amis !</p>
+      <p id="waiting-room-help">Partagez ce code de salle avec vos amis !</p>
       <div class="players-grid">
         <div class="player-slot" id="slot-nord">
           <div class="slot-label">Nord</div>
@@ -190,7 +207,8 @@
     <div id="chat-panel" aria-label="Chat de la partie">
       <div class="chat-header">
         <span>Chat</span>
-        <button id="btn-chat-close" class="btn btn-secondary btn-sm chat-close-btn" type="button" aria-label="Réduire le chat">Réduire</button>
+        <button id="btn-chat-close" class="btn btn-secondary btn-sm chat-close-btn" type="button"
+          aria-label="Réduire le chat">Réduire</button>
       </div>
       <div id="chat-messages" class="chat-messages"></div>
       <div class="chat-input-row">
@@ -200,7 +218,8 @@
     </div>
 
     <!-- Mobile: bouton d'ouverture du chat -->
-    <button id="btn-chat-open" class="btn btn-secondary btn-sm chat-open-btn" type="button" aria-label="Ouvrir le chat">Chat</button>
+    <button id="btn-chat-open" class="btn btn-secondary btn-sm chat-open-btn" type="button"
+      aria-label="Ouvrir le chat">Chat</button>
 
     <!-- Zone d'enchères -->
     <div id="bidding-panel" class="hidden">

--- a/public/style.css
+++ b/public/style.css
@@ -230,9 +230,9 @@ body {
 
 .lobby-container {
   text-align: center;
-  padding: 46px 40px 38px;
-  max-width: 540px;
-  width: 92%;
+  padding: clamp(26px, 4vw, 44px);
+  max-width: 940px;
+  width: min(94vw, 940px);
   border-radius: 30px;
   background:
     linear-gradient(180deg, rgba(249, 241, 217, 0.98) 0%, rgba(246, 236, 212, 0.96) 100%);
@@ -241,6 +241,8 @@ body {
     0 32px 70px rgba(0, 0, 0, 0.45),
     inset 0 1px 0 rgba(255, 255, 255, 0.6);
   backdrop-filter: blur(2px);
+  display: grid;
+  gap: 18px;
 }
 
 .brand-logo {
@@ -251,8 +253,8 @@ body {
 }
 
 .brand-logo-lobby {
-  width: min(220px, 52vw);
-  margin-bottom: 12px;
+  width: clamp(160px, 22vw, 230px);
+  margin-bottom: 8px;
 }
 
 .brand-logo-waiting {
@@ -262,32 +264,47 @@ body {
 
 .lobby-container h1 {
   font-family: 'Playfair Display', Georgia, serif;
-  font-size: clamp(2.0rem, 4.0vw, 3.0rem);
-  font-weight: 100;
-  margin-bottom: 8px;
-  letter-spacing: 0.02em;
+  font-size: clamp(2.1rem, 4.3vw, 4rem);
+  font-weight: 800;
+  line-height: 1.04;
+  margin-bottom: 4px;
+  letter-spacing: 0.015em;
   background: linear-gradient(165deg, #274855 0%, #67442f 48%, #954a2f 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
   text-shadow: none;
-  filter: drop-shadow(0 3px 10px rgba(39, 72, 85, 0.25));
+  filter: drop-shadow(0 4px 12px rgba(39, 72, 85, 0.2));
+}
+
+.lobby-title {
+  max-width: 18ch;
+  margin-inline: auto;
+  text-wrap: balance;
 }
 
 .subtitle {
-  color: #274855;
-  margin-bottom: 30px;
-  font-size: 13px;
-  letter-spacing: 2.6px;
-  text-transform: uppercase;
-  font-weight: 700;
+  color: #355867;
+  margin-bottom: 0;
+  font-size: 14px;
+  letter-spacing: 0.03em;
+  text-transform: none;
+  font-weight: 600;
+}
+
+.lobby-form {
+  display: grid;
+  gap: 16px;
+  width: 100%;
+  max-width: 860px;
+  margin: 0 auto;
 }
 
 .lobby-form input,
 .lobby-form select {
   width: 100%;
   padding: 13px 15px;
-  margin-bottom: 14px;
+  margin-bottom: 0;
   border: 1.5px solid rgba(39, 72, 85, 0.3);
   border-radius: 14px;
   background: rgba(255, 253, 248, 0.98);
@@ -309,16 +326,123 @@ body {
 }
 
 .lobby-actions {
-  display: flex;
-  gap: 16px;
-  margin-top: 20px;
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) auto minmax(240px, 1fr);
+  gap: 14px;
   align-items: stretch;
 }
 
+.public-menu {
+  padding: 16px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(252, 246, 231, 0.82), rgba(246, 236, 214, 0.74));
+  border: 1px solid rgba(39, 72, 85, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.public-menu h3 {
+  margin-bottom: 6px;
+  font-size: 13px;
+  color: #274855;
+  text-transform: uppercase;
+  letter-spacing: 1.7px;
+  font-weight: 800;
+}
+
+.public-menu-help {
+  margin: 0 0 10px;
+  font-size: 12px;
+  color: #45626e;
+  line-height: 1.35;
+}
+
+.public-menu-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.public-menu-actions .btn {
+  width: 100%;
+}
+
+.public-rooms-panel {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(39, 72, 85, 0.18);
+}
+
+.public-rooms-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  font-size: 13px;
+  color: #274855;
+  font-weight: 700;
+}
+
+.public-rooms-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 230px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.public-rooms-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.public-rooms-list::-webkit-scrollbar-thumb {
+  background: rgba(39, 72, 85, 0.24);
+  border-radius: 2px;
+}
+
+.public-room-entry {
+  display: grid;
+  grid-template-columns: 1fr minmax(140px, 42%);
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.52);
+  border: 1px solid rgba(39, 72, 85, 0.18);
+}
+
+.public-room-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+}
+
+.public-room-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: #274855;
+}
+
+.public-room-subtitle {
+  font-size: 12px;
+  color: #4c626b;
+}
+
+.public-rooms-empty {
+  font-size: 12px;
+  color: #5e6f77;
+  text-align: center;
+  padding: 10px 4px;
+}
+
 .action-group {
-  flex: 1;
+  display: grid;
+  align-content: start;
+  gap: 10px;
   background: linear-gradient(180deg, rgba(252, 246, 231, 0.98), rgba(246, 236, 214, 0.96));
-  padding: 20px 18px;
+  padding: 18px 16px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(39, 72, 85, 0.24);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
@@ -332,7 +456,7 @@ body {
 }
 
 .action-group h3 {
-  margin-bottom: 14px;
+  margin-bottom: 0;
   font-size: 12px;
   color: #67442f;
   text-transform: uppercase;
@@ -343,6 +467,7 @@ body {
 .separator {
   display: flex;
   align-items: center;
+  justify-content: center;
   color: #274855;
   font-weight: 700;
   font-size: 12px;
@@ -350,7 +475,8 @@ body {
   letter-spacing: 1px;
   background: rgba(249, 241, 217, 0.78);
   border: 1px solid rgba(39, 72, 85, 0.22);
-  padding: 0 12px;
+  min-width: 52px;
+  padding: 0 10px;
   border-radius: 999px;
 }
 
@@ -358,6 +484,14 @@ body {
   width: 100%;
   border-radius: 12px;
   border: 1px solid transparent;
+}
+
+.action-group .btn {
+  margin-top: 4px;
+}
+
+.public-room-entry .btn {
+  min-height: 42px;
 }
 
 #lobby .btn-primary {
@@ -382,7 +516,7 @@ body {
 
 .error-msg {
   color: #7a2c1f;
-  margin-top: 16px;
+  margin-top: 2px;
   padding: 12px 16px;
   background: rgba(149, 74, 47, 0.16);
   border-radius: var(--radius-md);
@@ -1724,12 +1858,24 @@ body.panel-dragging * {
   }
 
   .lobby-actions {
-    flex-direction: column;
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .public-menu-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .public-room-entry {
+    grid-template-columns: 1fr;
+    gap: 8px;
   }
 
   .separator {
     justify-content: center;
-    padding: 10px 0;
+    min-height: 36px;
+    width: 100%;
+    padding: 8px 0;
   }
 
   .table-layout {
@@ -1815,7 +1961,30 @@ body.panel-dragging * {
   }
 
   .lobby-container h1 {
-    font-size: 2.2em;
+    font-size: 2.35rem;
+    letter-spacing: 0.01em;
+  }
+
+  .lobby-container {
+    padding: 24px 14px 18px;
+    border-radius: 24px;
+  }
+
+  .lobby-form {
+    gap: 12px;
+  }
+
+  .action-group {
+    padding: 16px 12px;
+  }
+
+  .public-menu {
+    padding: 12px;
+  }
+
+  .public-rooms-header {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .brand-logo-lobby {
@@ -1901,6 +2070,7 @@ body.panel-dragging * {
    ============================================================ */
 
 @media (max-width: 600px) {
+
   /* Phone top HUD background */
   #mobile-top-panel {
     display: block;
@@ -2075,7 +2245,7 @@ body.panel-dragging * {
     pointer-events: none;
   }
 
-  #chat-panel > * {
+  #chat-panel>* {
     position: relative;
     z-index: 1;
   }
@@ -2110,6 +2280,7 @@ body.panel-dragging * {
    ============================================================ */
 
 @media (max-width: 600px) and (orientation: portrait) {
+
   /* Do not display other players' hands (card backs). */
   #hand-nord,
   #hand-est,
@@ -2179,6 +2350,7 @@ body.panel-dragging * {
    ============================================================ */
 
 @media (max-width: 600px) and (prefers-color-scheme: dark) {
+
   /* Opt into dark color-scheme only for the lobby (the game stays in light scheme). */
   #lobby {
     color-scheme: dark;
@@ -2272,6 +2444,7 @@ body.panel-dragging * {
 }
 
 @media (forced-colors: active) {
+
   #game-table,
   #game-table * {
     forced-color-adjust: none;

--- a/server.js
+++ b/server.js
@@ -13,9 +13,32 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 // Stockage des parties en cours
 const games = new Map();
+const PUBLIC_ROOM_PREFIX = 'PUB-';
+const PUBLIC_INACTIVE_MS = 5 * 60 * 1000;
+const PUBLIC_CLEANUP_INTERVAL_MS = 30 * 1000;
+
+const ROOM_NAME_NOUNS = [
+  'Table', 'Salon', 'Atout', 'Belote', 'Coinche', 'Pli', 'Trèfle', 'Carreau', 'Pique', 'Cœur'
+];
+
+const ROOM_NAME_ADJECTIVES = [
+  'Azur', 'Émeraude', 'Saphir', 'Rubis', 'Ivoire', 'Velours', 'Lumière', 'Brume', 'Nova', 'Orage'
+];
 
 function generateRoomCode() {
   return crypto.randomBytes(3).toString('hex').toUpperCase().slice(0, 6);
+}
+
+function sanitizeRoomName(name) {
+  if (typeof name !== 'string') return '';
+  return name.replace(/\s+/g, ' ').trim().slice(0, 28);
+}
+
+function generateRoomName() {
+  const noun = ROOM_NAME_NOUNS[Math.floor(Math.random() * ROOM_NAME_NOUNS.length)];
+  const adjective = ROOM_NAME_ADJECTIVES[Math.floor(Math.random() * ROOM_NAME_ADJECTIVES.length)];
+  const suffix = Math.floor(Math.random() * 90) + 10;
+  return `${noun} ${adjective} ${suffix}`;
 }
 
 function broadcastGameState(roomId) {
@@ -41,6 +64,65 @@ function formatBidPoints(points) {
   return `${points}`;
 }
 
+function getAvailablePositions(game) {
+  return POSITIONS.filter(pos => !game.players[pos]);
+}
+
+function pickRandom(arr) {
+  if (!arr || arr.length === 0) return null;
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function findOpenPublicRoom() {
+  for (const [roomId, game] of games.entries()) {
+    if (!game.isPublic) continue;
+    if (game.state !== 'waiting') continue;
+    if (game.isFull()) continue;
+    return { roomId, game };
+  }
+  return null;
+}
+
+function createPublicRoom() {
+  const roomId = `${PUBLIC_ROOM_PREFIX}${generateRoomCode()}`;
+  const game = new CoincheGame(roomId);
+  game.isPublic = true;
+  game.roomName = generateRoomName();
+  game.createdAt = Date.now();
+  game.lastActivityAt = Date.now();
+  games.set(roomId, game);
+  return { roomId, game };
+}
+
+function touchRoom(roomId) {
+  const game = games.get(roomId);
+  if (game && game.isPublic) {
+    game.lastActivityAt = Date.now();
+  }
+}
+
+function getPublicRoomList() {
+  const rooms = [];
+  const now = Date.now();
+
+  for (const [roomId, game] of games.entries()) {
+    if (!game.isPublic) continue;
+    if (game.state !== 'waiting') continue;
+    if (game.isFull()) continue;
+
+    const playerCount = POSITIONS.filter(pos => !!game.players[pos]).length;
+    rooms.push({
+      roomId,
+      roomName: game.roomName || roomId.replace(PUBLIC_ROOM_PREFIX, ''),
+      playerCount,
+      freeSeats: 4 - playerCount,
+      idleSeconds: Math.max(0, Math.floor((now - (game.lastActivityAt || now)) / 1000))
+    });
+  }
+
+  return rooms;
+}
+
 io.on('connection', (socket) => {
   console.log(`Joueur connecté: ${socket.id}`);
 
@@ -62,9 +144,10 @@ io.on('connection', (socket) => {
 
     currentRoom = roomId;
     socket.join(roomId);
-    socket.emit('room-created', { roomId, position });
+    socket.emit('room-created', { roomId, position, isPublic: false, displayCode: roomId });
     broadcastGameState(roomId);
     broadcastMessage(roomId, `${playerName} a créé la salle (${position})`);
+    touchRoom(roomId);
   });
 
   socket.on('join-room', (data) => {
@@ -96,9 +179,10 @@ io.on('connection', (socket) => {
 
     currentRoom = roomId;
     socket.join(roomId);
-    socket.emit('room-joined', { roomId, position });
+    socket.emit('room-joined', { roomId, position, isPublic: false, displayCode: roomId });
     broadcastGameState(roomId);
     broadcastMessage(roomId, `${playerName} a rejoint la salle (${position})`);
+    touchRoom(roomId);
 
     // Démarrer si 4 joueurs
     if (game.isFull() && game.state === 'waiting') {
@@ -106,6 +190,106 @@ io.on('connection', (socket) => {
       broadcastGameState(roomId);
       broadcastMessage(roomId, 'La partie commence ! Phase d\'enchères.', 'success');
     }
+  });
+
+  function startIfRoomReady(roomId, game) {
+    if (game.isFull() && game.state === 'waiting') {
+      game.startNewRound();
+      broadcastGameState(roomId);
+      broadcastMessage(roomId, 'La partie commence ! Phase d\'enchères.', 'success');
+      touchRoom(roomId);
+    }
+  }
+
+  function addSocketToPublicRoom({ createIfMissing, preferredRoomId = null, createdByPlayer = false }) {
+    if (currentRoom) return;
+
+    let room = null;
+
+    if (preferredRoomId) {
+      const preferredGame = games.get(preferredRoomId);
+      if (!preferredGame || !preferredGame.isPublic || preferredGame.state !== 'waiting' || preferredGame.isFull()) {
+        socket.emit('error-msg', { message: 'Cette salle publique n\'est plus disponible.' });
+        return;
+      }
+      room = { roomId: preferredRoomId, game: preferredGame };
+    } else {
+      room = findOpenPublicRoom();
+    }
+
+    if (!room && createIfMissing) {
+      room = createPublicRoom();
+    }
+
+    if (!room) {
+      socket.emit('error-msg', { message: 'Aucune salle publique disponible. Créez-en une.' });
+      return;
+    }
+
+    const { roomId, game } = room;
+    const availablePositions = getAvailablePositions(game);
+    const position = pickRandom(availablePositions);
+
+    if (!position) {
+      socket.emit('error-msg', { message: 'Aucune place disponible, réessaie.' });
+      return;
+    }
+
+    if (!game.addPlayer(socket.id, playerName, position)) {
+      socket.emit('error-msg', { message: 'Impossible de rejoindre la salle publique.' });
+      return;
+    }
+
+    currentRoom = roomId;
+    socket.join(roomId);
+
+    const createdByThisPlayer = createdByPlayer || (createIfMissing && game.players[position] && Object.keys(game.players).length === 1);
+    if (createdByThisPlayer) {
+      socket.emit('room-created', {
+        roomId,
+        position,
+        isPublic: true,
+        roomName: game.roomName,
+        displayCode: game.roomName
+      });
+      broadcastMessage(roomId, `${playerName} a créé une salle publique (${position})`);
+    } else {
+      socket.emit('room-joined', {
+        roomId,
+        position,
+        isPublic: true,
+        roomName: game.roomName,
+        displayCode: game.roomName
+      });
+      broadcastMessage(roomId, `${playerName} rejoint la partie publique (${position})`);
+    }
+
+    broadcastGameState(roomId);
+    touchRoom(roomId);
+    startIfRoomReady(roomId, game);
+  }
+
+  socket.on('create-public-room', (data) => {
+    playerName = (data?.name || 'Joueur').slice(0, 20);
+    const room = createPublicRoom();
+    room.game.roomName = sanitizeRoomName(data?.roomName) || room.game.roomName;
+    addSocketToPublicRoom({ createIfMissing: false, preferredRoomId: room.roomId, createdByPlayer: true });
+  });
+
+  socket.on('join-public-room', (data) => {
+    playerName = (data?.name || 'Joueur').slice(0, 20);
+    const roomId = (data?.roomId || '').toUpperCase().trim();
+    addSocketToPublicRoom({ createIfMissing: false, preferredRoomId: roomId || null });
+  });
+
+  socket.on('list-public-rooms', () => {
+    socket.emit('public-rooms', { rooms: getPublicRoomList() });
+  });
+
+  socket.on('quick-play', (data) => {
+    // Alias historique: quick-play = rejoindre public, ou créer si aucune salle ouverte.
+    playerName = (data?.name || 'Joueur').slice(0, 20);
+    addSocketToPublicRoom({ createIfMissing: true, preferredRoomId: null });
   });
 
   socket.on('bid', (data) => {
@@ -152,6 +336,7 @@ io.on('connection', (socket) => {
     }
 
     broadcastGameState(currentRoom);
+    touchRoom(currentRoom);
   });
 
   socket.on('play-card', (data) => {
@@ -192,6 +377,7 @@ io.on('connection', (socket) => {
     }
 
     broadcastGameState(currentRoom);
+    touchRoom(currentRoom);
   });
 
   socket.on('next-round', () => {
@@ -203,6 +389,7 @@ io.on('connection', (socket) => {
     game.startNewRound();
     broadcastGameState(currentRoom);
     broadcastMessage(currentRoom, 'Nouvelle manche ! Phase d\'enchères.');
+    touchRoom(currentRoom);
   });
 
   socket.on('new-game', () => {
@@ -218,6 +405,7 @@ io.on('connection', (socket) => {
     game.startNewRound();
     broadcastGameState(currentRoom);
     broadcastMessage(currentRoom, 'Nouvelle partie !', 'success');
+    touchRoom(currentRoom);
   });
 
   socket.on('get-available-positions', (data) => {
@@ -252,6 +440,7 @@ io.on('connection', (socket) => {
       text,
       timestamp: Date.now()
     });
+    touchRoom(currentRoom);
   });
 
   socket.on('disconnect', () => {
@@ -277,6 +466,27 @@ io.on('connection', (socket) => {
 });
 
 const PORT = process.env.PORT || 3000;
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [roomId, game] of games.entries()) {
+    if (!game.isPublic) continue;
+    if (game.state !== 'waiting') continue;
+    const lastActivity = game.lastActivityAt || game.createdAt || now;
+    if (now - lastActivity < PUBLIC_INACTIVE_MS) continue;
+
+    for (const pos of POSITIONS) {
+      const player = game.players[pos];
+      if (!player) continue;
+      io.to(player.id).emit('error-msg', { message: 'Salle publique inactive supprimée (5 min).' });
+      io.to(player.id).emit('public-room-closed', { roomId });
+    }
+
+    games.delete(roomId);
+    console.log(`Salle publique ${roomId} supprimée (inactive 5 min)`);
+  }
+}, PUBLIC_CLEANUP_INTERVAL_MS);
+
 server.listen(PORT, () => {
   console.log(`Serveur Coinche lancé sur http://localhost:${PORT}`);
 });


### PR DESCRIPTION
Implements public game rooms end-to-end: client UI, styles and interaction logic, plus server-side lifecycle and APIs.

Client: adds lobby UI for creating/joining/listing public rooms, buttons (create, join, refresh, quick-play), periodic refresh, rendering of room list, and updates waiting-room display for public rooms. Hooks socket events (public-rooms, public-room-closed) and requests list on load/interval.

Styles: updates lobby layout and typography, and introduces styles for the public rooms panel and responsive adjustments.

Server: introduces public room support (prefix, name generation, sanitization), handlers for create-public-room, join-public-room, list-public-rooms and quick-play, logic to pick/open public rooms, mark activity (touchRoom), and a cleanup interval that removes inactive public rooms after 5 minutes. Also updates emits to include isPublic/roomName/displayCode and touches rooms on relevant actions.

Overall: enables quick matchmaking via public rooms while keeping existing private room flows intact.